### PR TITLE
Allows setting different RKE2 supported CNI's

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,7 @@ resource "hcloud_server" "master" {
     INITIAL_MASTER       = count.index == 0 && !local.cluster_loadbalancer_running
     SERVER_ADDRESS       = hcloud_load_balancer.management_lb.ipv4
     INSTALL_RKE2_VERSION = var.rke2_version
+    RKE2_CNI             = var.rke2_cni
     OIDC_URL             = "https://${local.oidc_issuer_subdomain}"
   })
 

--- a/scripts/rke-master.sh.tpl
+++ b/scripts/rke-master.sh.tpl
@@ -18,6 +18,7 @@ token: ${RKE_TOKEN}
 tls-san:
   - ${SERVER_ADDRESS}
 cloud-provider-name: external
+cni: ${RKE2_CNI}
 node-ip: $NODE_IP
 %{ if EXPOSE_METRICS }
 etcd-expose-metrics: true

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,17 @@ variable "rke2_version" {
   description = "value for the rke2 version"
 }
 
+variable "rke2_cni" {
+  type        = string
+  default     = "canal"
+  description = "CNI type to use for the cluster"
+
+  validation {
+    condition     = contains(["canal","calico","cilium","none"], var.rke2_cni)
+    error_message = "The value for CNI must be either 'canal', 'cilium', 'calico' or 'none'."
+  }
+}
+
 variable "generate_ssh_key_file" {
   type        = bool
   default     = false


### PR DESCRIPTION
Allows setting any RKE2 supported CNI. Default to canal, since this is the current default.

* Tested deployments /w all three CNI's
* https://docs.rke2.io/install/network_options#install-a-cni-plugin

