### PR TITLE
Allows grouping hcloud resources by clustername

### DIFF
--- a/examples/simple-setup/variables.tf
+++ b/examples/simple-setup/variables.tf
@@ -4,25 +4,25 @@ variable "hetzner_token" {
 }
 
 variable "cloudflare_token" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The Cloudflare API token. (Required if create_cloudflare_dns_record is true.)"
 }
 
 variable "cloudflare_zone_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The Cloudflare zone id. (Required if create_cloudflare_dns_record is true.)"
 }
 
 variable "cloudflare_domain" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The Cloudflare domain. (Required if create_cloudflare_dns_record is true.)"
 }
 
 variable "letsencrypt_issuer" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The email to send notifications regarding let's encrypt."
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -1,5 +1,5 @@
 resource "hcloud_load_balancer" "management_lb" {
-  name               = "rke2-management-lb"
+  name               = "${var.cluster_name}-management-lb"
   load_balancer_type = "lb11"
   location           = var.lb_location
   labels = {

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "hcloud_server" "master" {
     hcloud_network_subnet.main
   ]
   count       = var.master_node_count
-  name        = "rke2-master-${lower(random_string.master_node_suffix[count.index].result)}"
+  name        = "${var.cluster_name}-master-${lower(random_string.master_node_suffix[count.index].result)}"
   server_type = var.master_node_server_type
   image       = var.master_node_image
   location    = element(var.node_locations, count.index)
@@ -75,7 +75,7 @@ resource "hcloud_server" "worker" {
     hcloud_network_subnet.main
   ]
   count       = var.worker_node_count
-  name        = "rke2-worker-${lower(random_string.worker_node_suffix[count.index].result)}"
+  name        = "${var.cluster_name}-worker-${lower(random_string.worker_node_suffix[count.index].result)}"
   server_type = var.worker_node_server_type
   image       = var.worker_node_image
   location    = element(var.node_locations, count.index)

--- a/network.tf
+++ b/network.tf
@@ -1,11 +1,15 @@
+locals {
+  network_address  = var.network_address != null ? var.network_address : "10.0.0.0/16"
+}
+
 resource "hcloud_network" "main" {
-  name     = "main-network"
-  ip_range = "10.0.0.0/16"
+  name     = "${var.cluster_name}-network"
+  ip_range = local.network_address
 }
 
 resource "hcloud_network_subnet" "main" {
   network_id   = hcloud_network.main.id
   type         = "cloud"
   network_zone = var.network_zone
-  ip_range     = "10.0.0.0/16"
+  ip_range     = local.network_address
 }

--- a/network.tf
+++ b/network.tf
@@ -1,15 +1,11 @@
-locals {
-  network_address  = var.network_address != null ? var.network_address : "10.0.0.0/16"
-}
-
 resource "hcloud_network" "main" {
   name     = "${var.cluster_name}-network"
-  ip_range = local.network_address
+  ip_range = var.network_address
 }
 
 resource "hcloud_network_subnet" "main" {
   network_id   = hcloud_network.main.id
   type         = "cloud"
   network_zone = var.network_zone
-  ip_range     = local.network_address
+  ip_range     = var.network_address
 }

--- a/ssh.tf
+++ b/ssh.tf
@@ -6,7 +6,7 @@ resource "local_file" "name" {
 }
 
 resource "hcloud_ssh_key" "main" {
-  name       = "main-ssh-key"
+  name       = "${var.cluster_name}-ssh-key"
   public_key = tls_private_key.machines.public_key_openssh
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "rke2_cni" {
   description = "CNI type to use for the cluster"
 
   validation {
-    condition     = contains(["canal","calico","cilium","none"], var.rke2_cni)
+    condition     = contains(["canal", "calico", "cilium", "none"], var.rke2_cni)
     error_message = "The value for CNI must be either 'canal', 'cilium', 'calico' or 'none'."
   }
 }
@@ -74,7 +74,7 @@ variable "network_zone" {
 
 variable "network_address" {
   type        = string
-  default     = null
+  default     = "10.0.0.0/16"
   description = "Define the network for the cluster in CIDR format (e.g,. '10.0.0.0/16')."
 }
 
@@ -133,7 +133,7 @@ variable "cluster_configuration" {
       use_for_preinstalled_components = optional(bool, true)
     }), {})
   })
-  default = {}
+  default     = {}
   description = "Define the cluster configuration. (See README.md for more information.)"
 
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,17 @@ variable "worker_node_count" {
   description = "value for the number of worker nodes"
 }
 
+variable "cluster_name" {
+  type        = string
+  default     = "rke2"
+  description = "value for the cluster name"
+
+  validation {
+    condition     = regex("^[a-z0-9]{1,20}$", var.cluster_name) != null
+    error_message = "The cluster name must be lowercase and alphanumeric and must not be longer than 20 characters."
+  }
+}
+
 variable "rke2_version" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "network_zone" {
   description = "Define the network location for the cluster."
 }
 
+variable "network_address" {
+  type        = string
+  default     = null
+  description = "Define the network for the cluster in CIDR format (e.g,. '10.0.0.0/16')."
+}
+
 variable "node_locations" {
   type        = list(string)
   default     = ["hel1", "nbg1", "fsn1"]


### PR DESCRIPTION
Allows setting a =< 20 character clustername to easily identify hcloud resources when deploying multiple clusters.
By default the current `rke2` prefix is used for servers and load-balancers. This allows setting a different prefix.